### PR TITLE
_services.get might return undefined

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -15,6 +15,7 @@ class Container {
 
     get(name) {
         const c = this._services.get(name)
+        if(c == undefined) throw new Error(`Container doesn't know type ${name}`);
 
         if(this._isClass(c.definition)) {
 


### PR DESCRIPTION
When the user requests an instance of an unknown class, the `get` functions should throw an error.